### PR TITLE
Add automated keymap visualization generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,3 +3,59 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   build:
     uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@main
+
+  draw:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN || github.token }}
+          
+      - name: Install keymap-drawer
+        run: pip3 install keymap-drawer
+      
+      - name: Parse ZMK keymap
+        run: keymap parse -c 12 -z config/sofle.keymap > keymap.yaml
+      
+      - name: Generate QWERTY layer image
+        run: |
+          keymap draw keymap.yaml -s "QWERTY" > qwerty_layer.svg
+          
+      - name: Generate LOWER layer image
+        run: |
+          keymap draw keymap.yaml -s "LOWER" > lower_layer.svg
+          
+      - name: Generate RAISE layer image
+        run: |
+          keymap draw keymap.yaml -s "RAISE" > raise_layer.svg
+          
+      - name: Generate CODING layer image
+        run: |
+          keymap draw keymap.yaml -s "CODING" > coding_layer.svg
+          
+      - name: Generate ADJUST layer image
+        run: |
+          keymap draw keymap.yaml -s "ADJUST" > adjust_layer.svg
+      
+      - name: Upload layer images as artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: keymap-images
+          path: |
+            qwerty_layer.svg
+            lower_layer.svg
+            raise_layer.svg
+            coding_layer.svg
+            adjust_layer.svg
+            
+      - name: Commit and push images (on main branch only)
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          mkdir -p images
+          mv *.svg images/
+          
+          git add images/*.svg
+          git diff --staged --quiet || (git commit -m "Update keymap layer images" && git push)

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Build artifacts
+build/
+*.uf2
+
+# Keymap drawer generated images (only generated in CI)
+*.svg
+images/*.svg
+keymap.yaml
+
+# Editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -16,15 +16,21 @@ This is a ZMK firmware configuration for the Sofle split keyboard, based on the 
 ### QWERTY (Base Layer)
 Standard QWERTY layout with ESC, TAB, and modifier keys in expected positions.
 
+![QWERTY Layer](images/qwerty_layer.svg)
+
 ### LOWER (Layer 1)
 - Function keys (F1-F12)
 - Number row
 - Symbols and special characters
 
+![LOWER Layer](images/lower_layer.svg)
+
 ### RAISE (Layer 2)
 - Navigation keys (arrows, page up/down, home/end)
 - Text editing shortcuts (copy, paste, cut, undo)
 - Word navigation (Ctrl+Left/Right)
+
+![RAISE Layer](images/raise_layer.svg)
 
 ### CODING (Layer 3)
 Development-focused macros:
@@ -32,11 +38,15 @@ Development-focused macros:
 - Kubernetes: get pods, get svc, logs, exec
 - Docker: ps, logs
 
+![CODING Layer](images/coding_layer.svg)
+
 ### ADJUST (Layer 4)
 System controls:
 - Bluetooth profile management
 - Media controls (volume, play/pause, next/prev)
 - Bootloader access
+
+![ADJUST Layer](images/adjust_layer.svg)
 
 ## Building
 

--- a/build.yaml
+++ b/build.yaml
@@ -17,3 +17,5 @@ include:
     shield: sofle_left
   - board: nice_nano_v2
     shield: sofle_right
+  - board: nice_nano_v2
+    shield: settings_reset


### PR DESCRIPTION
## Summary
- Add keymap-drawer to GitHub Actions for automated layer visualization
- Generate individual SVG images for each keyboard layer
- Include settings reset firmware for troubleshooting

## Changes
- **CI/CD**: Added `draw` job to GitHub Actions workflow that installs keymap-drawer and generates SVG visualizations for all layers
- **Documentation**: Updated README with image references for each layer (QWERTY, LOWER, RAISE, CODING, ADJUST)
- **Configuration**: Added `.gitignore` to ensure images are only generated via CI, not locally
- **Build**: Added settings_reset shield to build configuration for clearing stored settings

## Benefits
- Visual documentation is automatically kept in sync with keymap changes
- Each layer has its own dedicated visualization
- Settings reset firmware helps with Bluetooth troubleshooting
- Images are only generated in CI, keeping local development clean